### PR TITLE
Use join instead of run, to avoid infinite rendering errors

### DIFF
--- a/addon/components/async-image.js
+++ b/addon/components/async-image.js
@@ -4,7 +4,7 @@ import {
   computed
 } from '@ember/object';
 import {
-  run
+  join
 } from '@ember/runloop';
 import {
   getOwner
@@ -127,12 +127,12 @@ export default Component.extend({
 
       let Img = new Image();
       let loaded = () => {
-        run(() => {
+        join(() => {
           this._onload(Img);
         });
       };
       let failed = () => {
-        run(() => {
+        join(() => {
           this._onError(Img);
         });
       };


### PR DESCRIPTION
When many instances of the async-image component are present simultaneously (our example is an infinite scrolling page of photos), we encountered an "infinite rendering invalidation detected" error.  It appears to be a similar issue to the one described here: https://github.com/ember-redux/ember-redux/pull/69, wherein the use of `run` creates a new run loop for each async-image instance.

In order to avoid this issue, and as a general performance improvement, I've switched to using `join`, so that each async-image's `_onload` or `_onError` will queue itself on an existing run loop, if available.